### PR TITLE
import content_type_charset from HTTP::Headers. #5

### DIFF
--- a/t/charset.t
+++ b/t/charset.t
@@ -1,0 +1,12 @@
+use strict;
+
+use Test::More;
+plan tests => 2;
+
+use HTTP::Headers::Fast;
+
+my $h = HTTP::Headers::Fast->new;
+is($h->content_type_charset, undef);
+
+$h->content_type('text/plain; charset="iso-8859-1"');
+is($h->content_type_charset, "ISO-8859-1");


### PR DESCRIPTION
This copies over content_type_charset and split_header_words from HTTP::Headers