### PR TITLE
Make standard_case hash global to allow adding XS easily:

### DIFF
--- a/lib/HTTP/Headers/Fast.pm
+++ b/lib/HTTP/Headers/Fast.pm
@@ -50,7 +50,7 @@ my @header_order =
 # Make alternative representations of @header_order.  This is used
 # for sorting and case matching.
 my %header_order;
-my %standard_case;
+our %standard_case;
 
 {
     my $i = 0;


### PR DESCRIPTION
In order to implements parts of `HTTP::Headers::Fast` in XS, it needs access to the `%standard_case` hash which is used by other variables.

It's possible to reimplement that but it's easier to simply access the available Perl-side existing hash.

Making the `%standard_case` a global would make it easier for the XS to reach it without playing with the scratchpad.

For what it's worth, there are already some functions implemented in XS assuming that this variable is available.