### PR TITLE
Implement flatten method to build PSGI compatible header array

### DIFF
--- a/lib/HTTP/Headers/Fast.pm
+++ b/lib/HTTP/Headers/Fast.pm
@@ -350,6 +350,36 @@ sub as_string_without_sort {
     $self->_as_string($endl, [keys(%$self)]);
 }
 
+sub _flatten {
+    my $self = shift;
+    my @headers;
+    for my $key ( @{$_[0]} ) {
+        next if substr($key, 0, 1) eq '_';
+        my $vals = $self->{$key};
+        if ( ref($vals) eq 'ARRAY' ) {
+            for my $val (@$vals) {
+                $val =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
+                $val =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
+                push @headers, $standard_case{$key} || $key, $val;
+            }
+        }
+        else {
+            $vals =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
+            $vals =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
+            push @headers, $standard_case{$key} || $key, $vals;
+        }
+    }
+    return \@headers;
+}
+
+sub flatten {
+    $_[0]->_flatten($_[0]->_sorted_field_names);
+}
+
+sub flatten_without_sort {
+    $_[0]->_flatten([keys(%{$_[0]})]);
+}
+
 {
     my $storable_required;
     sub clone {
@@ -587,6 +617,16 @@ HTTP::Headers is a very good. But I needed a faster implementation, fast  =)
 as_string method sorts the header names.But, sorting is bit slow.
 
 In this method, stringify the instance of HTTP::Headers::Fast without sorting.
+
+=item flatten
+
+returns PSGI compatible arrayref of header.
+
+    my $headers:ArrayRef = $header->flatten
+
+=item flatten_without_sort
+
+same as flatten but returns arrayref without sorting.
 
 =back
 

--- a/lib/HTTP/Headers/Fast.pm
+++ b/lib/HTTP/Headers/Fast.pm
@@ -351,9 +351,9 @@ sub as_string_without_sort {
 }
 
 sub _flatten {
-    my $self = shift;
+    my ($self, $keys) = @_;
     my @headers;
-    for my $key ( @{$_[0]} ) {
+    for my $key ( @{$keys} ) {
         next if substr($key, 0, 1) eq '_';
         my $vals = $self->{$key};
         if ( ref($vals) eq 'ARRAY' ) {
@@ -376,8 +376,9 @@ sub flatten {
     $_[0]->_flatten($_[0]->_sorted_field_names);
 }
 
+
 sub flatten_without_sort {
-    $_[0]->_flatten([keys(%{$_[0]})]);
+    $_[0]->_flatten([keys %{$_[0]}]);
 }
 
 {
@@ -708,3 +709,4 @@ This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.
 
 =cut
+

--- a/t/headers_flatten.t
+++ b/t/headers_flatten.t
@@ -1,0 +1,51 @@
+#!perl -w
+
+use strict;
+use Test::More tests => 12;
+require HTTP::Headers::Fast;
+
+
+my $h = HTTP::Headers::Fast->new;
+is_deeply($h->flatten, []);
+
+$h = HTTP::Headers::Fast->new(foo => "bar", foo => "baaaaz", Foo => "baz");
+is_deeply($h->flatten, ['Foo','bar','Foo','baaaaz','Foo','baz']);
+is_deeply($h->flatten_without_sort, ['Foo','bar','Foo','baaaaz','Foo','baz']);
+
+$h = HTTP::Headers::Fast->new(foo => ["bar", "baz"]);
+is_deeply($h->flatten, ['Foo','bar','Foo','baz']);
+
+$h = HTTP::Headers::Fast->new(foo => 1, bar => 2, foo_bar => 3);
+is_deeply($h->flatten, ['Bar','2','Foo','1','Foo-Bar','3']);
+
+
+$h = HTTP::Headers::Fast->new(
+    a => "foo\r\n\r\nevil body" ,
+    b => "foo\015\012\015\012evil body" ,
+    c => "foo\x0d\x0a\x0d\x0aevil body" ,
+);
+is_deeply($h->flatten, [
+    'A', "fooevil body",
+    'B', "fooevil body",
+    'C', "fooevil body",
+    ]);
+
+$h = HTTP::Headers::Fast->new(
+    "Foo\000Bar" => "baz",
+    "Qux\177Quux" => "42"
+);
+is_deeply($h->flatten, [ "Foo\000Bar" => 'baz', "Qux\177Quux" => '42' ]);
+is_deeply(+{@{$h->flatten_without_sort}}, +{ "Foo\000Bar" => 'baz', "Qux\177Quux" => '42' });
+
+$h = HTTP::Headers::Fast->new(
+    "X-LWS-I"  => "Bar\r\n  true",
+    "X-LWS-II" => "Bar\r\n\t\ttrue"
+);
+is_deeply($h->flatten, [ 'X-LWS-I' => 'Bar true', 'X-LWS-II' => 'Bar true' ]);
+is_deeply(+{@{$h->flatten_without_sort}}, +{ 'X-LWS-I' => 'Bar true', 'X-LWS-II' => 'Bar true' });
+
+$h = HTTP::Headers::Fast->new(
+    "X-CR-LF" => "Foo\nBar\rBaz"
+);
+is_deeply($h->flatten, [ 'X-CR-LF' => 'FooBarBaz' ]);
+is_deeply($h->flatten_without_sort, [ 'X-CR-LF' => 'FooBarBaz' ]);


### PR DESCRIPTION
flatten is shortcut method for building PSGI compatible header array. `Plack::Response->finalize` may be  20-30% faster.

benchmark

```
% perl -Ilib benchmark.pl
                         Rate           scan        flatten flatten_without_sort
scan                  93458/s             --           -26%                 -39%
flatten              126582/s            35%             --                 -18%
flatten_without_sort 153846/s            65%            22%                   --
```

script

```
use strict;
use warnings;
use Benchmark qw/cmpthese/;
use HTTP::Headers::Fast;

my $h = HTTP::Headers::Fast->new(foo => 1, bar => 2, foo_bar => 3);

cmpthese(
    100000 => {
        scan => sub {
            my @headers;
            $h->scan(sub{
                my ($k,$v) = @_;
                $v =~ s/\015\012[\040|\011]+/chr(32)/ge; # replace LWS with a single SP
                $v =~ s/\015|\012//g; # remove CR and LF since the char is invalid here
                push @headers, $k, $v;
            });
        },
        flatten => sub { my $headers = $h->flatten() },
        flatten_without_sort => sub { my $headers = $h->flatten_without_sort() },
    },
);
```


