### PR TITLE
Add "content_is_text"

### DIFF
--- a/lib/HTTP/Headers/Fast.pm
+++ b/lib/HTTP/Headers/Fast.pm
@@ -510,6 +510,11 @@ sub _split_header_words
     return @res;
 }
 
+sub content_is_text {
+    my $self = shift;
+    return $self->content_type =~ m,^text/,;
+}
+
 sub content_is_html {
     my $self = shift;
     return $self->content_type eq 'text/html' || $self->content_is_xhtml;

--- a/t/headers.t
+++ b/t/headers.t
@@ -4,7 +4,7 @@ use strict;
 use Test qw(plan ok);
 use Test::Requires 'URI';
 
-plan tests => 164;
+plan tests => 171;
 
 my($h, $h2);
 sub j { join("|", @_) }
@@ -202,11 +202,18 @@ ok($h->header("content_type"), "text/html;\n charSet = \"ISO-8859-1\"; Foo=1 ");
 ok($h->content_is_html);
 ok(!$h->content_is_xhtml);
 ok(!$h->content_is_xml);
+ok($h->content_is_text);
 $h->content_type("application/xhtml+xml");
 ok($h->content_is_html);
 ok($h->content_is_xhtml);
 ok($h->content_is_xml);
-ok($h->content_type("text/html;\n charSet = \"ISO-8859-1\"; Foo=1 "), "application/xhtml+xml");
+ok(!$h->content_is_text);
+ok($h->content_type("text/plain"), "application/xhtml+xml");
+ok(!$h->content_is_html);
+ok(!$h->content_is_xhtml);
+ok(!$h->content_is_xml);
+ok($h->content_is_text);
+ok($h->content_type("text/html;\n charSet = \"ISO-8859-1\"; Foo=1 "), "text/plain");
 
 ok($h->content_encoding, undef);
 ok($h->content_encoding("gzip"), undef);


### PR DESCRIPTION
Hello!

I'm using HTTP::Headers::Fast with an HTTP::Message object, and decoded_content failed because this method is missing. So I copied it over from HTTP::Headers.

Cheers!