### PR TITLE
Skip lazy_load_for_storable.t if Storable is already loaded (fix #11, patch by Slaven Rezić)

### DIFF
--- a/t/lazy_load_for_storable.t
+++ b/t/lazy_load_for_storable.t
@@ -1,6 +1,13 @@
 use strict;
 use warnings;
+use Test::More;
+BEGIN {
+    if ($INC{"Storable.pm"}) {
+        plan skip_all => "Storable is already loaded by toolchain";
+    }
+}
 use HTTP::Headers::Fast;
-use Test::More tests => 1;
+
+plan tests => 1;
 
 is $INC{'Storable.pm'}, undef;


### PR DESCRIPTION
https://github.com/tokuhirom/HTTP-Headers-Fast/issues/11#issuecomment-456973320